### PR TITLE
Fix bot.botMentionAsPrefix and an event when no command is found.

### DIFF
--- a/src/handlers/messageCommands.ts
+++ b/src/handlers/messageCommands.ts
@@ -165,17 +165,19 @@ export async function handleMessageCommands(
   bot: AmethystBot,
   message: Message
 ) {
-  //Get prefix for this guild.
+  //Get prefix for this guild if the prefix is a function.
   const guildPrefix =
     typeof bot.prefix == "function"
       ? await bot.prefix(bot, message)
       : bot.prefix;
 
-  //
+  //Else get the string prefix and check if it works.
   let prefix =
     typeof guildPrefix == "string"
       ? guildPrefix
       : guildPrefix?.find((e) => message.content.toLowerCase().startsWith(e));
+
+  //If the bot.botMentionAsPrefix is a prefix.
   if (!prefix && bot.botMentionAsPrefix) {
     if (message.content.toLowerCase().startsWith(`<@${bot.id}>`))
       prefix = `<@${bot.id}>`;
@@ -183,13 +185,7 @@ export async function handleMessageCommands(
       prefix = `<@!${bot.id}>`;
   }
 
-  if (
-    !prefix ||
-    (typeof bot.prefix == "string" &&
-      !message.content.toLowerCase().startsWith(prefix))
-  ) {
-    return;
-  }
+  if (prefix === undefined) return bot.events.notMessageCommand?.(bot, message);
 
   const args = message.content.split(" ").filter((e) => Boolean(e.length));
   const commandName = args.shift()?.slice(prefix.length);

--- a/src/handlers/messageCommands.ts
+++ b/src/handlers/messageCommands.ts
@@ -84,6 +84,12 @@ import { createContext } from "../utils/createContext.ts";
     : args;
 }*/
 
+/**
+ * Execute a message command.
+ * @param bot
+ * @param message
+ * @param command
+ */
 function executeCommand(
   bot: AmethystBot,
   message: Message,
@@ -149,7 +155,12 @@ function executeCommand(
     } else throw e;
   }
 }
-
+/**
+ * Handling of incoming messageCommands.
+ * @param bot
+ * @param message
+ * @returns
+ */
 export async function handleMessageCommands(
   bot: AmethystBot,
   message: Message
@@ -174,7 +185,7 @@ export async function handleMessageCommands(
   const command = bot.commands.find((cmd) =>
     Boolean(cmd.name == commandName /*|| cmd.aliases?.includes(commandName!)*/)
   );
-  if (!command) return;
+  if (!command) return bot.events.commandNotFound?.(bot, message.prefix);
   if (message.guildId && !bot.members.has(message.authorId)) {
     bot.members.set(
       bot.transformers.snowflake(`${message.guildId}${message.guildId}`),

--- a/src/handlers/messageCommands.ts
+++ b/src/handlers/messageCommands.ts
@@ -175,13 +175,23 @@ export async function handleMessageCommands(
   let prefix =
     typeof guildPrefix == "string"
       ? guildPrefix
-      : guildPrefix?.find((e) => message.content.toLowerCase().startsWith(e));
+      : guildPrefix?.find((e) =>
+          bot.prefixCaseSensitive
+            ? message.content.startsWith(e)
+            : message.content.toLowerCase().startsWith(e.toLowerCase())
+        );
+
+  //If prefix is a string and not a array
+  if (typeof prefix == "string")
+    if (bot.prefixCaseSensitive)
+      if (!message.content.startsWith(prefix)) prefix = undefined;
+      else if (!message.content.toLowerCase().startsWith(prefix.toLowerCase()))
+        prefix = undefined;
 
   //If the bot.botMentionAsPrefix is a prefix.
   if (!prefix && bot.botMentionAsPrefix) {
-    if (message.content.toLowerCase().startsWith(`<@${bot.id}>`))
-      prefix = `<@${bot.id}>`;
-    else if (message.content.toLowerCase().startsWith(`<@!${bot.id}>`))
+    if (message.content.startsWith(`<@${bot.id}>`)) prefix = `<@${bot.id}>`;
+    else if (message.content.startsWith(`<@!${bot.id}>`))
       prefix = `<@!${bot.id}>`;
   }
 

--- a/src/interfaces/AmethystBotOptions.ts
+++ b/src/interfaces/AmethystBotOptions.ts
@@ -4,27 +4,26 @@ import { AmethystBot } from "./bot.ts";
 import { CommandCooldown } from "./command.ts";
 
 /**A list of options for the amethyst bot*/
-export type AmethystBotOptions =
-  & {
-    owners?: (bigint | string)[];
-    prefix?:
-      | string
-      | string[]
-      | ((bot: AmethystBot, message: Message) => Async<string | string[]>);
-    botMentionAsPrefix?: boolean;
-    defaultCooldown?: CommandCooldown;
-    ignoreCooldown?: (string | bigint)[];
-    commandDir?: string;
-    eventDir?: string;
-    inhibitorDir?: string;
-  }
-  & (
-    | {
+export type AmethystBotOptions = {
+  owners?: (bigint | string)[];
+  prefix?:
+    | string
+    | string[]
+    | ((bot: AmethystBot, message: Message) => Async<string | string[]>);
+  botMentionAsPrefix?: boolean;
+  defaultCooldown?: CommandCooldown;
+  ignoreCooldown?: (string | bigint)[];
+  commandDir?: string;
+  eventDir?: string;
+  inhibitorDir?: string;
+  prefixCaseSensitive?: boolean;
+} & (
+  | {
       guildOnly?: true;
       dmOnly?: false;
     }
-    | {
+  | {
       guildOnly?: false;
       dmOnly: true;
     }
-  );
+);

--- a/src/interfaces/bot.ts
+++ b/src/interfaces/bot.ts
@@ -112,6 +112,7 @@ interface AmethystProps extends Omit<BotWithCache, "events"> {
   >;
   owners?: bigint[];
   botMentionAsPrefix?: boolean;
+  prefixCaseSensitive?: boolean;
   defaultCooldown?: CommandCooldown;
   ignoreCooldown?: bigint[];
   guildOnly?: boolean;


### PR DESCRIPTION
When a user is mentioned the ping can be <@!{userId}> or <@{userId}>

And when no command is found some bot may want to inform their user that they could not find that command